### PR TITLE
Fix setup.py to capture all static files

### DIFF
--- a/globusauth_client/client.py
+++ b/globusauth_client/client.py
@@ -113,7 +113,7 @@ def profile_api_expo():
 def logout():
     if 'access' in session:
         headers = { "Authorization": "Bearer {}".format(session['access']) }
-        r = requests.delete(SERVICE_URL + "/token_details", headers=headers);
+        r = requests.delete(SERVICE_URL + "/token_details", headers=headers, verify=False);
     session.pop('access', None)
     session.pop('token', None)
     session.pop('resource_server', None)
@@ -133,7 +133,7 @@ def proxy(url):
     else:
         target = SERVICE_URL + "/{}".format(url)
         headers = { "Authorization": "Bearer {}".format(session['access']) }
-        r = requests.request(request.method, target, headers=headers, params=request.args)
+        r = requests.request(request.method, target, headers=headers, params=request.args, verify=False)
 
         if re.search('json', r.headers.get('content-type')):
             return jsonify(r.json())

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,21 @@
 import os
 from setuptools import setup, find_packages
 
+
+pkg_dir = os.path.join(os.path.dirname(__file__), 'globusauth_client')
+static_dir = os.path.join(pkg_dir, 'static')
+
+
+def all_static_files():
+    return reduce(lambda x, y: x+y,
+                  [[os.path.join(d, f)[len(pkg_dir)+1:] for f in fs]
+                   for (d, sds, fs) in os.walk(static_dir)])
+
 setup(
     name='globusauth_client',
     include_package_data=True,
-    package_data={'': ['*']},
+    package_data={'': ['templates/*.html'] + all_static_files()},
     packages=find_packages(),
-    package_dir={'': '.'}
+    package_dir={'': '.'},
+    zip_safe=False
 )


### PR DESCRIPTION
Changing to a non-zip-safe install with an explicit walk of the static files dir.
I can't say exactly why, but the `setup.py` we had before was working.
In retrospect, it's somewhat surprising that it was -- declaring a top-level wildcard match for `package_data` gives setuptools fits because it's too stoopid to see that `static/` is a directory.

In spite of the numerous requests I've seen for first-class support for this use case in setuptools, I haven't seen any mention of it being implemented.
Everyone seems to write helpers somewhat like this `os.walk` business.
That python helper uses nested comprehensions with ambiguous names, wrapped in a `reduce()`, and no comments, in order to appeal to Haskell junkies.
